### PR TITLE
Implemented RespondContent() allowing to reuse configured mock multip…

### DIFF
--- a/src/SimpleHttpMock/MockHandler.cs
+++ b/src/SimpleHttpMock/MockHandler.cs
@@ -1,11 +1,13 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace SimpleHttpMock
 {
     internal class MockHandler : DelegatingHandler
     {
-        private readonly RequestBehaviors requestBehaviors;
+        private RequestBehaviors requestBehaviors;
 
         public MockHandler(RequestBehaviors requestBehaviors)
         {
@@ -17,6 +19,13 @@ namespace SimpleHttpMock
             var tcs = new TaskCompletionSource<HttpResponseMessage>();
             tcs.SetResult(requestBehaviors.CreateResponse(request));
             return tcs.Task;
+        }
+
+        public void Reconfigure(IEnumerable<RequestBehavior> behaviors, bool deleteExistingMocks)
+        {
+            requestBehaviors = deleteExistingMocks
+                ? new RequestBehaviors(behaviors)
+                : new RequestBehaviors(behaviors.Concat(requestBehaviors.Behaviors));
         }
     }
 }

--- a/src/SimpleHttpMock/MockedHttpServer.cs
+++ b/src/SimpleHttpMock/MockedHttpServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Web.Http.SelfHost;
 
@@ -7,11 +8,13 @@ namespace SimpleHttpMock
     public class MockedHttpServer : IDisposable
     {
         private readonly HttpSelfHostServer httpSelfHostServer;
+        private readonly DelegatingHandler _byPassHandler;
 
         public MockedHttpServer(DelegatingHandler byPassHandler, string baseAddress, Action<HttpSelfHostConfiguration> setup = null)
         {
+            _byPassHandler = byPassHandler;
             var config = new HttpSelfHostConfiguration(baseAddress);
-            config.MessageHandlers.Add(byPassHandler);
+            config.MessageHandlers.Add(_byPassHandler);
             if (setup != null)
             {
                 setup(config);
@@ -23,6 +26,14 @@ namespace SimpleHttpMock
         public void Dispose()
         {
             httpSelfHostServer.CloseAsync().Wait();
+        }
+
+        internal void ReconfigureBehaviors(IEnumerable<RequestBehavior> behaviors, bool deleteExistingMocks)
+        {
+            var mockHandler = _byPassHandler as MockHandler;
+            if (mockHandler == null)
+                throw new NotSupportedException("MockedHttpServer has been constructed with handler not allowing reconfiguration");
+            mockHandler.Reconfigure(behaviors, deleteExistingMocks);
         }
     }
 }

--- a/src/SimpleHttpMock/MockedHttpServerBuilder.cs
+++ b/src/SimpleHttpMock/MockedHttpServerBuilder.cs
@@ -16,6 +16,11 @@ namespace SimpleHttpMock
             return new MockedHttpServer(handler, baseAddress, setup);
         }
 
+        public void Reconfigure(MockedHttpServer server, bool deleteExistingMocks)
+        {
+            server.ReconfigureBehaviors(builders.Select(b => b.Build()), deleteExistingMocks);
+        }
+
         public RequestBehaviorBuilder WhenGet(string uri)
         {
             return WhenGet(Matchers.Is(uri));

--- a/src/SimpleHttpMock/RequestBehaviorBuilder.cs
+++ b/src/SimpleHttpMock/RequestBehaviorBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using Newtonsoft.Json;
+using SimpleHttpMock.responses;
 
 namespace SimpleHttpMock
 {
@@ -61,15 +62,24 @@ namespace SimpleHttpMock
         public RequestBehaviorBuilder Respond(HttpStatusCode httpStatusCode, object response, Uri location = null)
         {
             statusCode = httpStatusCode;
-            Response = response;
+            Response = new ObjectResponseCreator(response);
             Location = location;
             return this;
         }
 
+        [Obsolete("This method creates mock that can be used only once, because after first call, the content instance is disposed. Please use a safer version of this method: RespondContent(code, request => new StringContent('my content'), location)")]
         public RequestBehaviorBuilder RespondContent(HttpStatusCode httpStatusCode, HttpContent content, Uri location = null)
         {
             statusCode = httpStatusCode;
-            Response = content;
+            Response = new HttpContentResponseCreator(request => content);
+            Location = location;
+            return this;
+        }
+
+        public RequestBehaviorBuilder RespondContent(HttpStatusCode httpStatusCode, Func<HttpRequestMessage,HttpContent> contentFn, Uri location = null)
+        {
+            statusCode = httpStatusCode;
+            Response = new HttpContentResponseCreator(contentFn);
             Location = location;
             return this;
         }
@@ -81,7 +91,7 @@ namespace SimpleHttpMock
             return this;
         }
 
-        protected object Response = string.Empty;
+        protected IResponseCreator Response = new ObjectResponseCreator(string.Empty);
 
         protected Uri Location = default(Uri);
 

--- a/src/SimpleHttpMock/RequestBehaviors.cs
+++ b/src/SimpleHttpMock/RequestBehaviors.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Formatting;
 
 namespace SimpleHttpMock
 {
@@ -19,35 +18,9 @@ namespace SimpleHttpMock
         {
             var httpRequestMessageWrapper = new HttpRequestMessageWrapper(request);
             var requestBehavior = behaviors.FirstOrDefault(behavior => behavior.Process(httpRequestMessageWrapper));
-            
+
             if (requestBehavior != null)
-            {
-                HttpResponseMessage httpResponseMessage;
-                var httpContent = requestBehavior.Response as HttpContent;
-
-                if (httpContent != null)
-                {
-                    var responseMessage = new HttpResponseMessage
-                    {
-                        Content = httpContent,
-                        StatusCode = requestBehavior.StatusCode
-                    };
-                    httpResponseMessage = responseMessage;
-                }
-                else
-                {
-                    httpResponseMessage = request.CreateResponse(requestBehavior.StatusCode, requestBehavior.Response);
-                }
-
-                var httpHeaders = requestBehavior.Headers;
-                if (httpHeaders != null && httpHeaders.Count > 0)
-                {
-                    httpHeaders.ToList().ForEach(header=>httpResponseMessage.Headers.Add(header.Key,header.Value));
-                }
-
-                httpResponseMessage.Headers.Location = requestBehavior.Location;
-                return httpResponseMessage;
-            }
+                return requestBehavior.CreateResponseMessage(request);
             return request.CreateResponse(HttpStatusCode.OK);
         }
     }

--- a/src/SimpleHttpMock/RequestBehaviors.cs
+++ b/src/SimpleHttpMock/RequestBehaviors.cs
@@ -7,17 +7,19 @@ namespace SimpleHttpMock
 {
     class RequestBehaviors
     {
-        private readonly IEnumerable<RequestBehavior> behaviors;
+        private readonly RequestBehavior[] _behaviors;
+
+        public IEnumerable<RequestBehavior> Behaviors { get { return _behaviors; } }
 
         public RequestBehaviors(IEnumerable<RequestBehavior> behaviors)
         {
-            this.behaviors = behaviors;
+            _behaviors = behaviors.ToArray();
         }
 
         public HttpResponseMessage CreateResponse(HttpRequestMessage request)
         {
             var httpRequestMessageWrapper = new HttpRequestMessageWrapper(request);
-            var requestBehavior = behaviors.FirstOrDefault(behavior => behavior.Process(httpRequestMessageWrapper));
+            var requestBehavior = Behaviors.FirstOrDefault(behavior => behavior.Process(httpRequestMessageWrapper));
 
             if (requestBehavior != null)
                 return requestBehavior.CreateResponseMessage(request);

--- a/src/SimpleHttpMock/responses/HttpContentResponseCreator.cs
+++ b/src/SimpleHttpMock/responses/HttpContentResponseCreator.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace SimpleHttpMock.responses
+{
+    public class HttpContentResponseCreator : IResponseCreator
+    {
+        private readonly Func<HttpRequestMessage, HttpContent> _contentFn;
+
+        public HttpContentResponseCreator(Func<HttpRequestMessage, HttpContent> contentFn)
+        {
+            _contentFn = contentFn;
+        }
+
+        public HttpResponseMessage CreateResponseFor(HttpRequestMessage request, HttpStatusCode statusCode)
+        {
+            return new HttpResponseMessage { Content = _contentFn(request), StatusCode = statusCode };
+        }
+    }
+}

--- a/src/SimpleHttpMock/responses/IResponseCreator.cs
+++ b/src/SimpleHttpMock/responses/IResponseCreator.cs
@@ -1,0 +1,10 @@
+using System.Net;
+using System.Net.Http;
+
+namespace SimpleHttpMock.responses
+{
+    public interface IResponseCreator
+    {
+        HttpResponseMessage CreateResponseFor(HttpRequestMessage request, HttpStatusCode statusCode);
+    }
+}

--- a/src/SimpleHttpMock/responses/ObjectResponseCreator.cs
+++ b/src/SimpleHttpMock/responses/ObjectResponseCreator.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace SimpleHttpMock.responses
+{
+    public class ObjectResponseCreator : IResponseCreator
+    {
+        private readonly object _content;
+
+        public ObjectResponseCreator(object content)
+        {
+            _content = content;
+        }
+
+        public HttpResponseMessage CreateResponseFor(HttpRequestMessage request, HttpStatusCode statusCode)
+        {
+            return request.CreateResponse(statusCode, _content);
+        }
+    }
+}

--- a/src/SimpleHttpMock/simple-http-mock.csproj
+++ b/src/SimpleHttpMock/simple-http-mock.csproj
@@ -75,6 +75,9 @@
     <Compile Include="RequestBehaviorBuilder.cs" />
     <Compile Include="RequestBehaviors.cs" />
     <Compile Include="RequestProcessor.cs" />
+    <Compile Include="responses\HttpContentResponseCreator.cs" />
+    <Compile Include="responses\IResponseCreator.cs" />
+    <Compile Include="responses\ObjectResponseCreator.cs" />
     <Compile Include="WildCardMatcher.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/unit-test/Facts.cs
+++ b/test/unit-test/Facts.cs
@@ -120,7 +120,45 @@ namespace test
                     Assert.Equal(result, response.Content.ReadAsStringAsync().Result); // raw string
                 }
             }
+        }
 
+        [Fact]
+        public void should_be_able_to_accept_http_content_multiple_times()
+        {
+            var builder = new MockedHttpServerBuilder();
+            const string result = " a \"c\" b ";
+            builder.WhenGet("/test")
+                .RespondContent(HttpStatusCode.OK, request=>new StringContent(result));
+            using (builder.Build("http://localhost:1122"))
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    Assert.Equal(result, 
+                        httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.Content.ReadAsStringAsync().Result); // raw string
+
+                    Assert.Equal(result, 
+                        httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.Content.ReadAsStringAsync().Result); // raw string
+                }
+            }
+
+        }
+
+        [Fact]
+        public void should_be_able_to_accept_raw_object()
+        {
+            var builder = new MockedHttpServerBuilder();
+            int result = 56;
+            builder.WhenGet("/test")
+                .Respond(HttpStatusCode.OK, result);
+            using (builder.Build("http://localhost:1122"))
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    var response = httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result;
+                    var actual = response.Content.ReadAsStringAsync().Result;
+                    Assert.Equal(result.ToString(), actual);
+                }
+            }
         }
 
         [Fact]

--- a/test/unit-test/Facts.cs
+++ b/test/unit-test/Facts.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SimpleHttpMock;
 using Xunit;
@@ -71,7 +72,7 @@ namespace test
             {
                 using (var httpClient = new HttpClient())
                 {
-                     const string result = @"[
+                    const string result = @"[
                       {
                         ""eventId"": ""e1fdf1f0-a66d-4f42-95e6-d6588cc22e9b"",
                         ""id"": 0
@@ -128,15 +129,15 @@ namespace test
             var builder = new MockedHttpServerBuilder();
             const string result = " a \"c\" b ";
             builder.WhenGet("/test")
-                .RespondContent(HttpStatusCode.OK, request=>new StringContent(result));
+                .RespondContent(HttpStatusCode.OK, request => new StringContent(result));
             using (builder.Build("http://localhost:1122"))
             {
                 using (var httpClient = new HttpClient())
                 {
-                    Assert.Equal(result, 
+                    Assert.Equal(result,
                         httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.Content.ReadAsStringAsync().Result); // raw string
 
-                    Assert.Equal(result, 
+                    Assert.Equal(result,
                         httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.Content.ReadAsStringAsync().Result); // raw string
                 }
             }
@@ -158,6 +159,76 @@ namespace test
                     var actual = response.Content.ReadAsStringAsync().Result;
                     Assert.Equal(result.ToString(), actual);
                 }
+            }
+        }
+
+        [Fact]
+        public void should_be_able_to_reconfigure_server_on_the_fly()
+        {
+            var builder = new MockedHttpServerBuilder();
+            const string content = " a \"c\" b ";
+            builder.WhenGet("/test")
+                .RespondContent(HttpStatusCode.OK, request => new StringContent(content));
+
+            using (var server = builder.Build("http://localhost:1122"))
+            using (var httpClient = new HttpClient())
+            {
+                var response = httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(content, response.Content.ReadAsStringAsync().Result);
+
+                var newBuilder = new MockedHttpServerBuilder();
+                newBuilder.WhenGet("/test").Respond(HttpStatusCode.BadRequest);
+
+                newBuilder.Reconfigure(server, true);
+
+                Assert.Equal(HttpStatusCode.BadRequest, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.StatusCode);
+            }
+        }
+
+        [Fact]
+        public void should_be_able_to_reconfigure_server_on_the_fly_with_preserving_existing_mocks()
+        {
+            var builder = new MockedHttpServerBuilder();
+            builder.WhenGet("/test").Respond(HttpStatusCode.BadRequest);
+            builder.WhenPut("/test").Respond(HttpStatusCode.Accepted);
+
+            using (var server = builder.Build("http://localhost:1122"))
+            using (var httpClient = new HttpClient())
+            {
+                Assert.Equal(HttpStatusCode.BadRequest, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.StatusCode);
+                Assert.Equal(HttpStatusCode.Accepted, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Put, "http://localhost:1122/test")).Result.StatusCode);
+
+                var newBuilder = new MockedHttpServerBuilder();
+                newBuilder.WhenGet("/test").Respond(HttpStatusCode.OK);
+                newBuilder.Reconfigure(server, false);
+
+                Assert.Equal(HttpStatusCode.OK, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.StatusCode);
+                Assert.Equal(HttpStatusCode.Accepted, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Put, "http://localhost:1122/test")).Result.StatusCode);
+            }
+        }
+
+        [Fact]
+        public void should_be_able_to_reconfigure_server_on_the_fly_with_removing_existing_mocks()
+        {
+            var builder = new MockedHttpServerBuilder();
+            builder.WhenGet("/test").Respond(HttpStatusCode.BadRequest);
+            builder.WhenPut("/test").Respond(HttpStatusCode.Accepted);
+
+            using (var server = builder.Build("http://localhost:1122"))
+            using (var httpClient = new HttpClient())
+            {
+                Assert.Equal(HttpStatusCode.BadRequest, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.StatusCode);
+                Assert.Equal(HttpStatusCode.Accepted, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Put, "http://localhost:1122/test")).Result.StatusCode);
+
+                var newBuilder = new MockedHttpServerBuilder();
+                newBuilder.WhenGet("/test").Respond(HttpStatusCode.InternalServerError);
+                newBuilder.Reconfigure(server, true);
+
+                //altered behavior
+                Assert.Equal(HttpStatusCode.InternalServerError, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.StatusCode);
+                //the default response
+                Assert.Equal(HttpStatusCode.OK, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Put, "http://localhost:1122/test")).Result.StatusCode);
             }
         }
 


### PR DESCRIPTION
Hello,

I have found a problem with multiple calls to a mock configured like below:
```c#
builder.WhenGet("/test")
    .RespondContent(HttpStatusCode.OK, new StringContent('some content'));
```
The problem is that after first call, the string content instance is being disposed, causing all further calls to fail.

As a solution for this problem, I have made this method obsolete with a warning message and created a safe version of it:

```c#
public RequestBehaviorBuilder RespondContent(HttpStatusCode httpStatusCode, Func<HttpRequestMessage,HttpContent> contentFn, Uri location = null) { }
```

where example usage is:

```c#
builder.WhenGet("/test")
    .RespondContent(HttpStatusCode.OK, request => new StringContent('some content'));
```

The difference is that on every call, the new StringContent instance is created, so it is possible to call this mock multiple times. Also, this method exposes ```request``` object which can be used to create a dynamic response, depending on request content.


Finally, I have made also a small refactoring on RequestBehavior class, making a Response property typized.

I would appreciate if this request would be accepted and a new package would be released on NuGet.

Thanks,
Wojtek

Ps. On the second commit, I have added an ability to reconfigure mocks on running server.
I hoped that it would be created as a separate pull request, but it looks like it is done in this as well.

Both changes would be very helpful for our team to work with SimpleHttpMock