### PR TITLE
Thread safety and default request behaviour

### DIFF
--- a/src/SimpleHttpMock/MockHandler.cs
+++ b/src/SimpleHttpMock/MockHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace SimpleHttpMock
@@ -21,6 +22,7 @@ namespace SimpleHttpMock
             return tcs.Task;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Reconfigure(IEnumerable<RequestBehavior> behaviors, bool deleteExistingMocks)
         {
             requestBehaviors = deleteExistingMocks

--- a/src/SimpleHttpMock/RequestBehaviors.cs
+++ b/src/SimpleHttpMock/RequestBehaviors.cs
@@ -23,7 +23,7 @@ namespace SimpleHttpMock
 
             if (requestBehavior != null)
                 return requestBehavior.CreateResponseMessage(request);
-            return request.CreateResponse(HttpStatusCode.OK);
+            return request.CreateResponse(HttpStatusCode.NotFound);
         }
     }
 

--- a/test/unit-test/Facts.cs
+++ b/test/unit-test/Facts.cs
@@ -228,7 +228,7 @@ namespace test
                 //altered behavior
                 Assert.Equal(HttpStatusCode.InternalServerError, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:1122/test")).Result.StatusCode);
                 //the default response
-                Assert.Equal(HttpStatusCode.OK, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Put, "http://localhost:1122/test")).Result.StatusCode);
+                Assert.Equal(HttpStatusCode.NotFound, httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Put, "http://localhost:1122/test")).Result.StatusCode);
             }
         }
 

--- a/test/unit-test/HarmcrestGrammarFacts.cs
+++ b/test/unit-test/HarmcrestGrammarFacts.cs
@@ -14,7 +14,7 @@ namespace test
         [Theory]
         [InlineData("/staffs", HttpStatusCode.InternalServerError)]
         [InlineData("/users", HttpStatusCode.InternalServerError)]
-        [InlineData("/assignees", HttpStatusCode.OK)]
+        [InlineData("/assignees", HttpStatusCode.NotFound)]
         public void should_support_is_regex(string url, HttpStatusCode expectedStatusCode)
         {
             var serverBuilder = new MockedHttpServerBuilder();


### PR DESCRIPTION
Hello,

I would like to request a merge of following changes:
* made SimpleHttpMock.Reconfigure() method thread safe
* changed default request behaviour to return NotFound instead of OK

The first change is really a safety fix.

The second change is behavioral one, where I have found that returning OK Http Status code by default is misleading, as normally this status would be expected from properly mocked requests.

With this change, if by some reason request is incorrectly mocked, the service under test would get NotFound status and would be failing with this reason, so it would be easier to find out that there is something wrong with mocks.
When it was OK status, we have had to spend much more time to understand why service was failing while the mock seemed to be right.

Thanks,
Wojtek